### PR TITLE
[feat] 자체 로그인 구현 

### DIFF
--- a/ZenServer/build.gradle
+++ b/ZenServer/build.gradle
@@ -18,12 +18,26 @@ repositories {
 }
 
 dependencies {
-	// Spring
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	//db
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.security:spring-security-test'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// test
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// db
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/user/domain/User.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/user/domain/User.java
@@ -1,0 +1,68 @@
+package com.zen.ZenServer.api.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "_user")
+public class User implements UserDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nickname;
+
+    private String email;
+
+    private String password;
+
+
+
+    //============================ UserDetail Method ============================//
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/user/repository/UserRepository.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.zen.ZenServer.api.user.repository;
+
+import com.zen.ZenServer.api.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String username);
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/auth/TokenType.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/auth/TokenType.java
@@ -1,0 +1,7 @@
+package com.zen.ZenServer.global.auth;
+
+public enum TokenType {
+
+    ACCESS_TOKEN,
+    REFRESH_TOKEN
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/auth/controller/AuthenticationController.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/auth/controller/AuthenticationController.java
@@ -1,0 +1,33 @@
+package com.zen.ZenServer.global.auth.controller;
+
+import com.zen.ZenServer.global.auth.dto.request.AuthenticationRequest;
+import com.zen.ZenServer.global.auth.dto.request.RegisterRequest;
+import com.zen.ZenServer.global.auth.dto.response.AuthenticationResponse;
+import com.zen.ZenServer.global.auth.service.AuthenticationService;
+import com.zen.ZenServer.global.response.ApiResponseDto;
+import com.zen.ZenServer.global.response.enums.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AuthenticationController {
+
+    private final AuthenticationService authenticationService;
+
+    @PostMapping("/v1/auth/register")
+    public ApiResponseDto<AuthenticationResponse> register(@RequestBody RegisterRequest registerRequest) {
+
+        return ApiResponseDto.success(SuccessCode.AUTH_REGISTER_SUCCESS, authenticationService.register(registerRequest));
+    }
+
+    @PostMapping("/v1/auth/authenticate")
+    public ApiResponseDto<AuthenticationResponse> authenticate(@RequestBody AuthenticationRequest authenticationRequest) {
+
+        return  ApiResponseDto.success(SuccessCode.AUTH_AUTHENTICATE_SUCCESS, authenticationService.authenticate(authenticationRequest));
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/auth/domain/Token.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/auth/domain/Token.java
@@ -1,0 +1,28 @@
+package com.zen.ZenServer.global.auth.domain;
+
+import com.zen.ZenServer.api.user.domain.User;
+import com.zen.ZenServer.global.auth.TokenType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Token {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    @Column(unique = true)
+    public String token;
+
+    public TokenType tokenType;
+
+    public boolean isExpired;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    public User user;
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/auth/dto/request/AuthenticationRequest.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/auth/dto/request/AuthenticationRequest.java
@@ -1,0 +1,7 @@
+package com.zen.ZenServer.global.auth.dto.request;
+
+public record AuthenticationRequest(
+        String email,
+        String password
+) {
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/auth/dto/request/RegisterRequest.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/auth/dto/request/RegisterRequest.java
@@ -1,0 +1,9 @@
+package com.zen.ZenServer.global.auth.dto.request;
+
+
+public record RegisterRequest(
+        String nickname,
+        String email,
+        String password
+) {
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/auth/dto/response/AuthenticationResponse.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/auth/dto/response/AuthenticationResponse.java
@@ -1,0 +1,11 @@
+package com.zen.ZenServer.global.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AuthenticationResponse(
+        Long userId,
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/auth/repository/TokenRepository.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/auth/repository/TokenRepository.java
@@ -1,0 +1,15 @@
+package com.zen.ZenServer.global.auth.repository;
+
+import com.zen.ZenServer.api.user.domain.User;
+import com.zen.ZenServer.global.auth.domain.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+
+    List<Token> findAllValidTokenByUser(User user);
+
+    Optional<Token> findByToken(String token);
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/auth/service/AuthenticationService.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/auth/service/AuthenticationService.java
@@ -1,0 +1,102 @@
+package com.zen.ZenServer.global.auth.service;
+
+import com.zen.ZenServer.api.user.domain.User;
+import com.zen.ZenServer.api.user.dto.response.UserResponse;
+import com.zen.ZenServer.api.user.repository.UserRepository;
+import com.zen.ZenServer.global.auth.TokenType;
+import com.zen.ZenServer.global.auth.domain.Token;
+import com.zen.ZenServer.global.auth.dto.request.AuthenticationRequest;
+import com.zen.ZenServer.global.auth.dto.request.RegisterRequest;
+import com.zen.ZenServer.global.auth.dto.response.AuthenticationResponse;
+import com.zen.ZenServer.global.auth.repository.TokenRepository;
+import com.zen.ZenServer.global.exception.CustomException;
+import com.zen.ZenServer.global.jwt.JwtTokenProvider;
+import com.zen.ZenServer.global.response.enums.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthenticationService  {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final TokenRepository tokenRepository;
+    private final AuthenticationManager authenticationManager;
+    private final PasswordEncoder passwordEncoder;
+
+    public AuthenticationResponse register(RegisterRequest registerRequest) {
+
+        if (userRepository.findByEmail(registerRequest.email()).isPresent()) {
+            throw new CustomException(ErrorCode.DUPLICATED_EMAIL_USER);
+        }
+
+        User user = User.builder()
+                .nickname(registerRequest.nickname())
+                .email(registerRequest.email())
+                .password(passwordEncoder.encode(registerRequest.password()))
+                .build();
+
+        userRepository.save(user);
+
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        saveUserToken(user, accessToken, TokenType.ACCESS_TOKEN);
+        saveUserToken(user, refreshToken, TokenType.REFRESH_TOKEN);
+
+        return new AuthenticationResponse(user.getId(), accessToken, refreshToken);
+    }
+
+    public AuthenticationResponse authenticate(AuthenticationRequest authenticationRequest) {
+
+        User user = userRepository.findByEmail(authenticationRequest.email())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        authenticationRequest.email(),
+                        authenticationRequest.password()
+                )
+        );
+
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        saveUserToken(user, accessToken, TokenType.ACCESS_TOKEN);
+        saveUserToken(user, refreshToken, TokenType.REFRESH_TOKEN);
+
+        return new AuthenticationResponse(user.getId(), accessToken, refreshToken);
+    }
+
+    private void saveUserToken(User user, String jwtToken, TokenType tokenType) {
+
+        Token token = Token.builder()
+                .user(user)
+                .token(jwtToken)
+                .tokenType(tokenType)
+                .isExpired(false)
+                .build();
+
+        tokenRepository.save(token);
+    }
+
+    public void revokeAllUserTokens(User user) {
+
+        List<Token> validTokens = tokenRepository.findAllValidTokenByUser(user);
+
+        if (!validTokens.isEmpty()) {
+            validTokens.forEach(token -> {
+                token.setExpired(true);
+            });
+            tokenRepository.saveAll(validTokens);
+        }
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/jwt/JwtAuthenticationFilter.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package com.zen.ZenServer.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws IOException, ServletException {
+
+        // TODO: "/auth"로 변경
+        if (request.getServletPath().contains("/v1")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = jwtTokenProvider.resolveToken(request);
+        jwtTokenProvider.validToken(token);
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/jwt/JwtTokenProvider.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,119 @@
+package com.zen.ZenServer.global.jwt;
+
+import com.zen.ZenServer.global.auth.domain.Token;
+import com.zen.ZenServer.global.auth.repository.TokenRepository;
+import com.zen.ZenServer.global.exception.CustomException;
+import com.zen.ZenServer.global.response.enums.ErrorCode;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class JwtTokenProvider {
+
+    @Value("${application.security.jwt.key}")
+    private String jwtKey;
+
+    @Value("${application.security.jwt.expiration}")
+    private long jwtExpiration;
+
+    @Value("${application.security.refresh.expiration}")
+    private long refreshExpiration;
+
+    private final UserDetailsService userDetailsService;
+
+    private final TokenRepository tokenRepository;
+
+    @PostConstruct
+    protected void init() {
+        jwtKey = Base64.getEncoder().encodeToString(jwtKey.getBytes());
+    }
+
+    public String createAccessToken(UserDetails userDetails) {
+
+        return buildToken(userDetails, jwtExpiration);
+    }
+
+    public String createRefreshToken(UserDetails userDetails) {
+
+        return buildToken(userDetails, refreshExpiration);
+    }
+
+    public String buildToken(UserDetails userDetails, long expiration) {
+
+        Date now = new Date();
+
+        Claims claims = Jwts.claims()
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expiration));
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(
+                jwtKey.getBytes());
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserPk(token));
+
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    public String getUserPk(String token) {
+
+        return getBody(token).getSubject();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring("Bearer ".length());
+        } else {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+
+    public void validToken(String token) {
+
+        Optional<Token> validToken = tokenRepository.findByToken(token);
+
+        if (token.isEmpty()) {
+            throw new CustomException(ErrorCode.EMPTY_TOKEN);
+        } else if (validToken.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        } else if (validToken.get().isExpired) {
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
+        }
+    }
+
+    private Claims getBody(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/ErrorCode.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/ErrorCode.java
@@ -14,6 +14,15 @@ public enum ErrorCode {
     MISSING_REQUIRED_PARAMETER(40002, HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
 
     // 401 Unauthorized
+    UNAUTHORIZED_MEMBER(40101, HttpStatus.UNAUTHORIZED, "계정 정보가 존재하지 않습니다"),
+    WRONG_PASSWORD(40102, HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다"),
+    EXPIRED_TOKEN(40103, HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
+    INVALID_TOKEN(40104, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    EMPTY_TOKEN(40105, HttpStatus.UNAUTHORIZED, "토큰이 비어있습니다." ),
+
+    // 403 FORBIDDEN
+    INVALID_AUTH_USER(40301, HttpStatus.FORBIDDEN, "권한 정보가 없는 사용자입니다"),
+    ACCESS_DENIED(40302,  HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
 
     // 404 Not Found
     NOT_FOUND_END_POINT(40400, HttpStatus.NOT_FOUND, "존재하지 않는 API입니다."),
@@ -21,6 +30,9 @@ public enum ErrorCode {
 
     // 405 Method Not Allowed Error
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),
+
+    // 409 Conflict
+    DUPLICATED_EMAIL_USER(40900, HttpStatus.CONFLICT, "존재하는 이메일입니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/SuccessCode.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/SuccessCode.java
@@ -9,8 +9,10 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
 
     // 200 OK
+    TEST_SUCCESS(20000, HttpStatus.CREATED, "test 성공"),
 
-    TEST_SUCCESS(20000, HttpStatus.CREATED, "test 성공");
+    AUTH_REGISTER_SUCCESS(200, HttpStatus.OK, "회원가입 성공"),
+    AUTH_AUTHENTICATE_SUCCESS(200, HttpStatus.OK, "로그인(사용자 인증) 성공");
 
     // 201 Created
     private final int code;

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/security/ApplicationConfig.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/security/ApplicationConfig.java
@@ -1,0 +1,38 @@
+package com.zen.ZenServer.global.security;
+
+import com.zen.ZenServer.api.user.repository.UserRepository;
+import com.zen.ZenServer.global.exception.CustomException;
+import com.zen.ZenServer.global.response.enums.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+public class ApplicationConfig {
+    private final UserRepository repository;
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return username -> repository.findByEmail(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_AUTH_USER));
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService());
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/security/SecurityConfig.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/security/SecurityConfig.java
@@ -1,0 +1,56 @@
+package com.zen.ZenServer.global.security;
+
+import com.zen.ZenServer.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableMethodSecurity
+public class SecurityConfig {
+    private final AuthenticationProvider authenticationProvider;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            // csrf 설정 disable (토큰 사용)
+            .csrf(AbstractHttpConfigurer::disable)
+
+            // 접근 주소별 권한 설정
+            .authorizeHttpRequests((authorize) ->
+                    authorize.requestMatchers(
+                                    "/api/**").permitAll()
+                            .anyRequest().authenticated()
+            )
+
+            // STATELESS (session 사용 x)
+            .sessionManagement((session) ->
+                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+
+            .authenticationProvider(authenticationProvider)
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}
+


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #5

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
회원가입 및 로그인 관련 상태코드를 추가했습니다.
jwt token 기능을 구현했습니다.
회원가입 및 로그인(사용자 인증) 기능을 구현했습니다.

## 📬 구현화면
<!-- postman 스크린샷 혹은 구현된 화면을 첨부해주세요 -->

- 회원가입
<img width="1005" alt="스크린샷 2024-07-18 오전 12 15 48" src="https://github.com/user-attachments/assets/67a7b2a5-d71a-4a9a-b542-564aea8083a6">

- 로그인
<img width="989" alt="스크린샷 2024-07-18 오전 12 15 38" src="https://github.com/user-attachments/assets/b1e173dd-23b2-442c-8ec8-829e98eac836">