### PR TITLE
[feat] 기획에 따른 tetris 도메인 기능 구현

### DIFF
--- a/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/controller/TetrisController.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/controller/TetrisController.java
@@ -1,0 +1,41 @@
+package com.zen.ZenServer.api.tetris.controller;
+
+import com.zen.ZenServer.api.tetris.dto.request.TetrisSaveRequest;
+import com.zen.ZenServer.api.tetris.dto.response.TetrisResultListResponse;
+import com.zen.ZenServer.api.tetris.dto.response.TetrisResultResponse;
+import com.zen.ZenServer.api.tetris.service.TetrisService;
+import com.zen.ZenServer.global.response.ApiResponseDto;
+import com.zen.ZenServer.global.response.enums.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class TetrisController {
+
+    private final TetrisService tetrisService;
+
+    @PostMapping("/v1/tetris/save")
+    public ApiResponseDto<Void> saveTetrisResult(@RequestBody TetrisSaveRequest tetrisSaveRequest) {
+        tetrisService.saveTetrisResult(tetrisSaveRequest);
+
+        return ApiResponseDto.success(SuccessCode.TETRIS_SAVE_GAME_RESULT_SUCCESS);
+    }
+
+    @GetMapping("/v1/tetris/list/year/{year}/month/{month}/user/{userId}")
+    public ApiResponseDto<List<TetrisResultListResponse>> getTetrisResultListByYearMonth(
+            @PathVariable("year") Integer year,
+            @PathVariable("month") Integer month,
+            @PathVariable("userId") Long userId
+    ) {
+        return ApiResponseDto.success(SuccessCode.TETRIS_GET_RESULT_LIST_SUCCESS, tetrisService.getTetrisResultList(userId, year, month));
+    }
+
+    @GetMapping("/v1/tetris/game/{gameId}")
+    public ApiResponseDto<TetrisResultResponse> getTetrisResult(@PathVariable("gameId") Long gameId) {
+        return ApiResponseDto.success(SuccessCode.TETRIS_GET_RESULT_SUCCESS, tetrisService.getTetrisResult(gameId));
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/domain/TetrisResult.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/domain/TetrisResult.java
@@ -1,0 +1,40 @@
+package com.zen.ZenServer.api.tetris.domain;
+
+import com.zen.ZenServer.api.baseHeart.domain.BaseHeart;
+import com.zen.ZenServer.api.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TetrisResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int score;
+    private int level;
+    private int lives;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private BaseHeart baseHeartRate;
+
+    @ElementCollection
+    private List<Integer> heartRateList;
+
+    private LocalDateTime gameStartTime;
+    private LocalDateTime gameEndTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/dto/request/TetrisSaveRequest.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/dto/request/TetrisSaveRequest.java
@@ -1,0 +1,17 @@
+package com.zen.ZenServer.api.tetris.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TetrisSaveRequest (
+
+        Long userId,
+        List<Integer> heartRateList,
+        Long baseHeartId,
+        int level,
+        int score,
+        int lives,
+        LocalDateTime gameStartTime,
+        LocalDateTime gameEndTime
+) {
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/dto/response/TetrisResultListResponse.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/dto/response/TetrisResultListResponse.java
@@ -1,0 +1,16 @@
+package com.zen.ZenServer.api.tetris.dto.response;
+
+
+import com.zen.ZenServer.api.tetris.domain.TetrisResult;
+
+import java.time.LocalDateTime;
+
+public record TetrisResultListResponse(
+        Long id,
+        int lives,
+        LocalDateTime startTime
+) {
+    public static TetrisResultListResponse toResponse(TetrisResult tetrisResult) {
+        return new TetrisResultListResponse(tetrisResult.getId(), tetrisResult.getLives(), tetrisResult.getGameStartTime());
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/dto/response/TetrisResultResponse.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/dto/response/TetrisResultResponse.java
@@ -1,0 +1,41 @@
+package com.zen.ZenServer.api.tetris.dto.response;
+
+
+import com.zen.ZenServer.api.baseHeart.domain.BaseHeart;
+import com.zen.ZenServer.api.baseHeart.dto.response.BaseHeartResponse;
+import com.zen.ZenServer.api.tetris.domain.TetrisResult;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TetrisResultResponse (
+        Long id,
+        int score,
+        int level,
+        int lives,
+        Duration playTime,
+        BaseHeartResponse baseHeartRate,
+        List<Integer> heartRateList,
+        Double averageHearRate,
+        LocalDateTime gameStartTime
+) {
+    public static TetrisResultResponse toResponse(TetrisResult tetrisResult) {
+        BaseHeart baseHeart = tetrisResult.getBaseHeartRate();
+
+        return new TetrisResultResponse(
+                tetrisResult.getId(),
+                tetrisResult.getScore(),
+                tetrisResult.getLevel(),
+                tetrisResult.getLives(),
+                Duration.between(tetrisResult.getGameStartTime(), tetrisResult.getGameEndTime()),
+                new BaseHeartResponse(baseHeart.getId(), baseHeart.getBaseHeart(), baseHeart.getMeasureTime()),
+                tetrisResult.getHeartRateList(),
+                tetrisResult.getHeartRateList().stream()
+                    .mapToInt(Integer::intValue)
+                    .average()
+                    .orElse(0.0),
+                tetrisResult.getGameStartTime()
+        );
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/repository/TetrisRepository.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/repository/TetrisRepository.java
@@ -1,0 +1,17 @@
+package com.zen.ZenServer.api.tetris.repository;
+
+import com.zen.ZenServer.api.tetris.domain.TetrisResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TetrisRepository extends JpaRepository<TetrisResult, Long> {
+    @Query("SELECT tr FROM TetrisResult tr WHERE YEAR(tr.gameStartTime) = :year AND MONTH(tr.gameStartTime) = :month AND tr.user.id = :userId ORDER BY tr.gameStartTime DESC")
+    List<TetrisResult> findByYearAndMonth(@Param("year") Integer year, @Param("month") Integer month, @Param("userId") Long userId);
+
+    @Query("SELECT tr FROM TetrisResult tr WHERE tr.user.id = :userId AND tr.id = :gameId")
+    Optional<TetrisResult> findByUserIdAndGameId(@Param("userId") Long userId, @Param("gameId") Long gameId);
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/service/TetrisService.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/tetris/service/TetrisService.java
@@ -1,0 +1,65 @@
+package com.zen.ZenServer.api.tetris.service;
+
+import com.zen.ZenServer.api.baseHeart.domain.BaseHeart;
+import com.zen.ZenServer.api.baseHeart.repository.BaseHeartRepository;
+import com.zen.ZenServer.api.tetris.domain.TetrisResult;
+import com.zen.ZenServer.api.tetris.dto.request.TetrisSaveRequest;
+import com.zen.ZenServer.api.tetris.dto.response.TetrisResultListResponse;
+import com.zen.ZenServer.api.tetris.dto.response.TetrisResultResponse;
+import com.zen.ZenServer.api.tetris.repository.TetrisRepository;
+import com.zen.ZenServer.api.user.domain.User;
+import com.zen.ZenServer.api.user.repository.UserRepository;
+import com.zen.ZenServer.global.exception.CustomException;
+import com.zen.ZenServer.global.response.enums.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TetrisService {
+
+    private final TetrisRepository tetrisRepository;
+    private final BaseHeartRepository baseHeartRepository;
+    private final UserRepository userRepository;
+
+    public void saveTetrisResult(TetrisSaveRequest tetrisSaveRequest) {
+
+        BaseHeart baseHeart = baseHeartRepository.findById(tetrisSaveRequest.baseHeartId())
+                .orElseThrow(() -> new CustomException(ErrorCode.BASE_HEART_NOT_FOUND));
+
+        User user = userRepository.findById(tetrisSaveRequest.userId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        TetrisResult tetrisResult = TetrisResult.builder()
+                .level(tetrisSaveRequest.level())
+                .score(tetrisSaveRequest.score())
+                .lives(tetrisSaveRequest.lives())
+                .baseHeartRate(baseHeart)
+                .heartRateList(tetrisSaveRequest.heartRateList())
+                .gameStartTime(tetrisSaveRequest.gameStartTime())
+                .gameEndTime(tetrisSaveRequest.gameEndTime())
+                .user(user)
+                .build();
+
+        tetrisRepository.save(tetrisResult);
+    }
+
+    public List<TetrisResultListResponse> getTetrisResultList(Long userId, Integer year, Integer month) {
+        List<TetrisResult> tetrisResults = tetrisRepository.findByYearAndMonth(year, month, userId);
+
+        return tetrisResults.stream().map(TetrisResultListResponse::toResponse).collect(Collectors.toList());
+    }
+
+    public TetrisResultResponse getTetrisResult(Long gameId) {
+        TetrisResult tetrisResult = tetrisRepository.findById(gameId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GAME_RESULT));
+
+        return TetrisResultResponse.toResponse(tetrisResult);
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/ErrorCode.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     NOT_FOUND_END_POINT(40400, HttpStatus.NOT_FOUND, "존재하지 않는 API입니다."),
     USER_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "해당 유저는 존재하지 않습니다."),
     BASE_HEART_NOT_FOUND(40402, HttpStatus.NOT_FOUND, "base 심박이 존재하지 않습니다."),
+    NOT_FOUND_GAME_RESULT(40403, HttpStatus.NOT_FOUND, "게임 결과가 존재하지 않습니다." ),
 
     // 405 Method Not Allowed Error
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/SuccessCode.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/SuccessCode.java
@@ -14,7 +14,9 @@ public enum SuccessCode {
     AUTH_REGISTER_SUCCESS(200, HttpStatus.OK, "회원가입 성공"),
     AUTH_AUTHENTICATE_SUCCESS(200, HttpStatus.OK, "로그인(사용자 인증) 성공"),
     HEART_SAVE_BASE_SUCCESS(200, HttpStatus.OK, "base 심박 저장 성공"),
-
+    TETRIS_SAVE_GAME_RESULT_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 저장 성공"),
+    TETRIS_GET_RESULT_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 조회 성공"),
+    TETRIS_GET_RESULT_LIST_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 리스트 조회 성공");
 
     private final int code;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #10

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 테트리스 게임 결과 저장 기능을 구현하였습니다.
- 월별 테트리스 게임 결과 리스트 조회 기능을 구현하였습니다.
- 테트리스 게임 결과 조회 기능을 구현하였습니다. 

## 📬 구현화면
<!-- postman 스크린샷 혹은 구현된 화면을 첨부해주세요 -->
- 테트리스 게임 결과 저장
<img width="847" alt="스크린샷 2024-07-18 오전 4 29 15" src="https://github.com/user-attachments/assets/3f0b6340-5436-4032-8103-c387a9bf47a3">

- 월별 테트리스 게임 결과 리스트 조회
<img width="877" alt="스크린샷 2024-07-18 오전 4 29 30" src="https://github.com/user-attachments/assets/c750fd96-46d2-4f53-b7b8-5b0c64a1fbd7">

- 테트리스 게임 결과 조회
<img width="933" alt="스크린샷 2024-07-18 오전 4 29 54" src="https://github.com/user-attachments/assets/3a2e1b7e-dfda-489e-8417-1f11a95b19ed">
