### PR TITLE
[feat] user 답변 저장 api 구현 #13

### DIFF
--- a/ZenServer/build.gradle
+++ b/ZenServer/build.gradle
@@ -49,6 +49,10 @@ dependencies {
 
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
+	//Gpt
+	implementation 'com.theokanning.openai-gpt3-java:client:0.10.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/ZenServer/src/main/java/com/zen/ZenServer/ZenServerApplication.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/ZenServerApplication.java
@@ -2,8 +2,10 @@ package com.zen.ZenServer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ZenServerApplication {
 
 	public static void main(String[] args) {

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/controller/EmotionDiaryController.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/controller/EmotionDiaryController.java
@@ -1,0 +1,34 @@
+package com.zen.ZenServer.api.emotionDiary.controller;
+
+import com.zen.ZenServer.api.emotionDiary.dto.EmotionDiaryPostRequest;
+import com.zen.ZenServer.api.emotionDiary.service.EmotionDiaryService;
+import com.zen.ZenServer.global.client.gpt.GptService;
+import com.zen.ZenServer.global.response.ApiResponseDto;
+import com.zen.ZenServer.global.response.enums.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class EmotionDiaryController {
+
+    private final EmotionDiaryService emotionDiaryService;
+    private final GptService gptService;
+
+    @PostMapping("/emotion-diary")
+    public ApiResponseDto postEmotionDiary(@RequestBody EmotionDiaryPostRequest request) {
+        Long userId = 1L;
+
+        String gptAnswer = gptService.getAnswer(request);
+        // 응답 데이터 자르기
+        if (gptAnswer.length() > 255) {
+            gptAnswer = gptAnswer.substring(0, 255);
+        }
+        emotionDiaryService.postEmotionDiary(userId,request,gptAnswer);
+        return ApiResponseDto.success(SuccessCode.EMOTIONDIARY_POST_SUCCESS);
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/domain/EmotionDiary.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/domain/EmotionDiary.java
@@ -1,0 +1,33 @@
+package com.zen.ZenServer.api.emotionDiary.domain;
+
+import com.zen.ZenServer.global.domain.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class EmotionDiary extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private String inputText;
+
+    private String gptAnswer;
+
+    private String userCharacter;
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/domain/EmotionDiary.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/domain/EmotionDiary.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/domain/UserCharacter.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/domain/UserCharacter.java
@@ -1,0 +1,16 @@
+package com.zen.ZenServer.api.emotionDiary.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserCharacter {
+
+    BAO("BAO"),
+    SKY("SKY"),
+    MOZZI("MOZZI"),
+    ;
+
+    private final String name;
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/dto/EmotionDiaryPostRequest.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/dto/EmotionDiaryPostRequest.java
@@ -1,0 +1,8 @@
+package com.zen.ZenServer.api.emotionDiary.dto;
+
+public record EmotionDiaryPostRequest(
+        String	userInput,      //	사용자 입력 답변 요약한 내용
+        String	character,      //	캐릭터
+        String	emotionState	//  감정상태
+){
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/repository/EmotionDiaryRepository.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/repository/EmotionDiaryRepository.java
@@ -1,0 +1,7 @@
+package com.zen.ZenServer.api.emotionDiary.repository;
+
+import com.zen.ZenServer.api.emotionDiary.domain.EmotionDiary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmotionDiaryRepository extends JpaRepository<EmotionDiary, Long> {
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/service/EmotionDiaryService.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/service/EmotionDiaryService.java
@@ -1,0 +1,31 @@
+package com.zen.ZenServer.api.emotionDiary.service;
+
+import com.zen.ZenServer.api.emotionDiary.domain.EmotionDiary;
+import com.zen.ZenServer.api.emotionDiary.dto.EmotionDiaryPostRequest;
+import com.zen.ZenServer.api.emotionDiary.repository.EmotionDiaryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmotionDiaryService {
+
+    private final EmotionDiaryRepository emotionDiaryRepository;
+    //private final OpenAiService openAiService;
+
+    @Transactional
+    public void postEmotionDiary(Long userId, EmotionDiaryPostRequest request, String gptAnswer) {
+
+        EmotionDiary emotionDiary = EmotionDiary.builder()
+                .userId(userId)
+                .userCharacter(request.character())
+                .inputText(request.userInput())
+                .gptAnswer(gptAnswer)
+                .build();
+
+        emotionDiaryRepository.save(emotionDiary);
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/user/controller/UserController.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/user/controller/UserController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User", description = "유저 관련 API 입니다.")
@@ -25,7 +26,7 @@ public class UserController {
         return info;
     }
 
-    @GetMapping("/background")
+    @PostMapping("/background")
     @Operation(
             summary = "배경을 변경합니다.",
             description = "배경을 변경합니다."

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/user/domain/User.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/user/domain/User.java
@@ -14,7 +14,6 @@ import java.util.Collection;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "_user")
-
 public class User implements UserDetails {
 
     @Id

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/user/domain/User.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/user/domain/User.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "_user")
+
 public class User implements UserDetails {
 
     @Id
@@ -28,6 +29,7 @@ public class User implements UserDetails {
   
     private Long leaf;
 
+    @Setter
     private Long background_id;
 
 

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptProperties.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptProperties.java
@@ -1,0 +1,22 @@
+package com.zen.ZenServer.global.client.gpt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "chatgpt")
+public class GptProperties {
+    private String authorization;
+    private String bearer;
+    private String model;
+    private Integer maxToken;
+    private Boolean stream;
+    private String role;
+    private Double temperature;
+    private String mediaType;
+    private String url;
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptRequest.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptRequest.java
@@ -1,0 +1,12 @@
+package com.zen.ZenServer.global.client.gpt;
+
+import java.util.List;
+
+public record GptRequest(
+        String model,
+        List<Message> messages,
+        double temperature,
+        int max_tokens,
+        boolean stream
+) {
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptResponse.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptResponse.java
@@ -1,0 +1,24 @@
+package com.zen.ZenServer.global.client.gpt;
+
+import java.util.List;
+
+public record GptResponse(
+        String id,
+        String object,
+        long created,
+        String model,
+        Usage usage,
+        List<Choice> choices
+) {
+    public record Usage(
+            int promptTokens,
+            int completionTokens,
+            int totalTokens
+    ) {}
+
+    public record Choice(
+            Message message,
+            String finishReason,
+            int index
+    ) {}
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptService.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptService.java
@@ -1,0 +1,56 @@
+package com.zen.ZenServer.global.client.gpt;
+
+import com.zen.ZenServer.api.emotionDiary.dto.EmotionDiaryPostRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GptService {
+
+    private final GptProperties gptProperties;
+    private final WebClient webClient;
+
+    public String getAnswer(EmotionDiaryPostRequest request) {
+        String userInput = request.userInput();
+
+        // GPT-3.5 Turbo API 호출
+        GptRequest gptRequest = new GptRequest(
+                gptProperties.getModel(),
+                List.of(new Message(gptProperties.getRole(), userInput)),
+                gptProperties.getTemperature(),
+                gptProperties.getMaxToken(),
+                false
+        );
+
+        GptResponse gptResponse = createCompletion(gptRequest);
+
+        // GPT-3.5 응답에서 첫 번째 선택지를 반환
+        return gptResponse.choices().get(0).message().content().trim();
+    }
+
+    public GptResponse createCompletion(GptRequest gptRequest) {
+        try {
+            return webClient.post()
+                    .uri(gptProperties.getUrl())
+                    .header("Authorization", gptProperties.getBearer() + gptProperties.getAuthorization())
+                    .header("Content-Type", gptProperties.getMediaType())
+                    .bodyValue(gptRequest)
+                    .retrieve()
+                    .bodyToMono(GptResponse.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            // 로그에 상세 오류 메시지를 기록합니다.
+            System.err.println("Error: " + e.getStatusCode() + " " + e.getResponseBodyAsString());
+            throw e;
+        } catch (Exception e) {
+            // 기타 예외 처리
+            e.printStackTrace();
+            throw new RuntimeException("An error occurred while creating completion request", e);
+        }
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptService.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptService.java
@@ -1,6 +1,8 @@
 package com.zen.ZenServer.global.client.gpt;
 
 import com.zen.ZenServer.api.emotionDiary.dto.EmotionDiaryPostRequest;
+import com.zen.ZenServer.global.exception.CustomException;
+import com.zen.ZenServer.global.response.enums.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -50,7 +52,7 @@ public class GptService {
         } catch (Exception e) {
             // 기타 예외 처리
             e.printStackTrace();
-            throw new RuntimeException("An error occurred while creating completion request", e);
+            throw new CustomException(ErrorCode.GPT_SERVER_ERROR);
         }
     }
 }

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/Message.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/Message.java
@@ -1,0 +1,7 @@
+package com.zen.ZenServer.global.client.gpt;
+
+public record Message(
+        String role,
+        String content
+) {
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/config/GptConfig.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/config/GptConfig.java
@@ -1,0 +1,50 @@
+package com.zen.ZenServer.global.config;
+
+import com.zen.ZenServer.global.client.gpt.GptProperties;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@Configuration
+@EnableConfigurationProperties(GptProperties.class)
+public class GptConfig {
+}
+
+/*
+@Configuration
+public class GptConfig {
+
+    @Value("${openai.api.key}")
+    private String openAiApiKey;
+
+    @Bean
+    public RestTemplate restTemplate(){
+        RestTemplate template = new RestTemplate();
+        template.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add(
+                    "Authorization"
+                    ,"Bearer "+openAiApiKey);
+            return execution.execute(request,body);
+        });
+
+        return template;
+
+    }
+}
+
+@Configuration
+public class ChatGptConfig {
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String BEARER = "Bearer ";
+    public static final String CHAT_MODEL = "gpt-3.5-turbo";
+    public static final Integer MAX_TOKEN = 300;
+    public static final Boolean STREAM = false;
+    public static final String ROLE = "user";
+    public static final Double TEMPERATURE = 0.6;
+    //public static final Double TOP_P = 1.0;
+    public static final String MEDIA_TYPE = "application/json; charset=UTF-8";
+    //completions : 질답
+    public static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
+}
+
+ */

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/config/WebClientConfig.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/config/WebClientConfig.java
@@ -1,0 +1,16 @@
+package com.zen.ZenServer.global.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}
+

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/domain/BaseTimeEntity.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.zen.ZenServer.global.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/ErrorCode.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/ErrorCode.java
@@ -39,7 +39,8 @@ public enum ErrorCode {
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
     PRESIGNED_URL_GET_ERROR(50001, HttpStatus.INTERNAL_SERVER_ERROR, "S3 presigned url을 받아오기에 실패했습니다."),
-    IMAGE_DELETE_ERROR(50002, HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 삭제가 실패했습니다.");
+    IMAGE_DELETE_ERROR(50002, HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 삭제가 실패했습니다."),
+    GPT_SERVER_ERROR(50003, HttpStatus.INTERNAL_SERVER_ERROR,"gpt통신 중 에러가 발생했습니다.");
 
     private final int code;
     private final HttpStatus httpStatus;

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/SuccessCode.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/SuccessCode.java
@@ -16,7 +16,8 @@ public enum SuccessCode {
     HEART_SAVE_BASE_SUCCESS(200, HttpStatus.OK, "base 심박 저장 성공"),
     TETRIS_SAVE_GAME_RESULT_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 저장 성공"),
     TETRIS_GET_RESULT_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 조회 성공"),
-    TETRIS_GET_RESULT_LIST_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 리스트 조회 성공");
+    TETRIS_GET_RESULT_LIST_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 리스트 조회 성공"),
+    EMOTIONDIARY_POST_SUCCESS(200,HttpStatus.OK,"사용자 답변 저장 성공");
 
     private final int code;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #13 


## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- user 답변 저장 api 구현했습니다.
    - 사용자가 입력한 내용을 입력받고 해당 내용을 기반으로 gpt와 통신을 진행했습니다.
    - 통신을 통해 넘겨받은 답변을 emotionDiary에 저장했습니다.
- conflict를 해결했습니다.
    -  setter를 달아주었습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 현재는 프롬프팅이 진행되지 않은 통신만 구현되었습니다. 고도화 진행하겠습니다.

## 📬 구현화면
<!-- postman 스크린샷 혹은 구현된 화면을 첨부해주세요 -->
<img width="1470" alt="스크린샷 2024-07-18 오후 7 14 01" src="https://github.com/user-attachments/assets/02097846-547a-46a9-8f81-ee709de08956">
<img width="1036" alt="스크린샷 2024-07-18 오후 7 14 27" src="https://github.com/user-attachments/assets/03fc5847-0f7b-4896-b229-a2b08762d9ea">