### PR TITLE
[feat] 유저에 해당하는 일기 전체 조회 api 구현 #17

### DIFF
--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/controller/EmotionDiaryController.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/controller/EmotionDiaryController.java
@@ -1,11 +1,14 @@
 package com.zen.ZenServer.api.emotionDiary.controller;
 
-import com.zen.ZenServer.api.emotionDiary.dto.EmotionDiaryPostRequest;
+import com.zen.ZenServer.api.emotionDiary.dto.request.EmotionDiaryPostRequest;
+import com.zen.ZenServer.api.emotionDiary.dto.response.EmotionDiaryListGetResponse;
 import com.zen.ZenServer.api.emotionDiary.service.EmotionDiaryService;
 import com.zen.ZenServer.global.client.gpt.GptService;
 import com.zen.ZenServer.global.response.ApiResponseDto;
 import com.zen.ZenServer.global.response.enums.SuccessCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,13 +22,19 @@ public class EmotionDiaryController {
     private final EmotionDiaryService emotionDiaryService;
     private final GptService gptService;
 
+    Long userId = 1L;
+
     @PostMapping("/emotion-diary")
     public ApiResponseDto postEmotionDiary(@RequestBody EmotionDiaryPostRequest request) {
-        Long userId = 1L;
 
         String gptAnswer = gptService.getAnswer(request);
 
         emotionDiaryService.postEmotionDiary(userId,request,gptAnswer);
         return ApiResponseDto.success(SuccessCode.EMOTIONDIARY_POST_SUCCESS);
+    }
+
+    @GetMapping("/diary-list")
+    public ApiResponseDto<List<EmotionDiaryListGetResponse>> getDiaryList() {
+        return ApiResponseDto.success(SuccessCode.EMOTIONDIARY_LIST_GET_SUCCESS,emotionDiaryService.getEmotionDiaryList(userId));
     }
 }

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/dto/request/EmotionDiaryPostRequest.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/dto/request/EmotionDiaryPostRequest.java
@@ -1,4 +1,4 @@
-package com.zen.ZenServer.api.emotionDiary.dto;
+package com.zen.ZenServer.api.emotionDiary.dto.request;
 
 public record EmotionDiaryPostRequest(
         String	userInput,      //	사용자 입력 답변 요약한 내용

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/dto/response/EmotionDiaryListGetResponse.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/dto/response/EmotionDiaryListGetResponse.java
@@ -1,0 +1,11 @@
+package com.zen.ZenServer.api.emotionDiary.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record EmotionDiaryListGetResponse(
+        String character,
+        String date,
+        Long emotionDiaryId
+) {
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/repository/EmotionDiaryRepository.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/repository/EmotionDiaryRepository.java
@@ -1,7 +1,9 @@
 package com.zen.ZenServer.api.emotionDiary.repository;
 
 import com.zen.ZenServer.api.emotionDiary.domain.EmotionDiary;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmotionDiaryRepository extends JpaRepository<EmotionDiary, Long> {
+    List<EmotionDiary> findByUserId(Long userId);
 }

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/service/EmotionDiaryService.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/service/EmotionDiaryService.java
@@ -1,9 +1,13 @@
 package com.zen.ZenServer.api.emotionDiary.service;
 
 import com.zen.ZenServer.api.emotionDiary.domain.EmotionDiary;
-import com.zen.ZenServer.api.emotionDiary.dto.EmotionDiaryPostRequest;
+import com.zen.ZenServer.api.emotionDiary.dto.request.EmotionDiaryPostRequest;
+import com.zen.ZenServer.api.emotionDiary.dto.response.EmotionDiaryListGetResponse;
 import com.zen.ZenServer.api.emotionDiary.repository.EmotionDiaryRepository;
-import jakarta.transaction.Transactional;
+import com.zen.ZenServer.global.Util.DateUtil;
+import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,7 +18,6 @@ import org.springframework.stereotype.Service;
 public class EmotionDiaryService {
 
     private final EmotionDiaryRepository emotionDiaryRepository;
-    //private final OpenAiService openAiService;
 
     @Transactional
     public void postEmotionDiary(Long userId, EmotionDiaryPostRequest request, String gptAnswer) {
@@ -27,5 +30,19 @@ public class EmotionDiaryService {
                 .build();
 
         emotionDiaryRepository.save(emotionDiary);
+    }
+
+    @Transactional(readOnly = true)
+    public List<EmotionDiaryListGetResponse> getEmotionDiaryList(Long userId) {
+        List<EmotionDiary> emotionDiaryList = emotionDiaryRepository.findByUserId(userId);
+
+       return emotionDiaryList.stream()
+                .map(oneEmotionDiary ->
+                        EmotionDiaryListGetResponse.builder()
+                        .character(oneEmotionDiary.getUserCharacter())
+                        .date(DateUtil.refineDate(oneEmotionDiary.getCreatedAt()))
+                        .emotionDiaryId(oneEmotionDiary.getId())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/user/repository/UserRepository.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/user/repository/UserRepository.java
@@ -1,10 +1,17 @@
 package com.zen.ZenServer.api.user.repository;
 
 import com.zen.ZenServer.api.user.domain.User;
+import com.zen.ZenServer.global.exception.CustomException;
+import com.zen.ZenServer.global.response.enums.ErrorCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String username);
+
+    default User findByIdByOrThrow(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
 }

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/Util/DateUtil.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/Util/DateUtil.java
@@ -1,0 +1,13 @@
+package com.zen.ZenServer.global.Util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DateUtil {
+    public static String refineDate(LocalDateTime localDateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+        return localDateTime.format(formatter);
+    }
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptService.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/client/gpt/GptService.java
@@ -1,6 +1,6 @@
 package com.zen.ZenServer.global.client.gpt;
 
-import com.zen.ZenServer.api.emotionDiary.dto.EmotionDiaryPostRequest;
+import com.zen.ZenServer.api.emotionDiary.dto.request.EmotionDiaryPostRequest;
 import com.zen.ZenServer.global.exception.CustomException;
 import com.zen.ZenServer.global.response.enums.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/SuccessCode.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/SuccessCode.java
@@ -17,7 +17,8 @@ public enum SuccessCode {
     TETRIS_SAVE_GAME_RESULT_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 저장 성공"),
     TETRIS_GET_RESULT_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 조회 성공"),
     TETRIS_GET_RESULT_LIST_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 리스트 조회 성공"),
-    EMOTIONDIARY_POST_SUCCESS(200,HttpStatus.OK,"사용자 답변 저장 성공");
+    EMOTIONDIARY_POST_SUCCESS(200,HttpStatus.OK,"사용자 답변 저장 성공"),
+    EMOTIONDIARY_LIST_GET_SUCCESS(200,HttpStatus.OK,"유저에 해당하는 일기 전체 조회 성공");
 
     private final int code;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #17 


## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
유저에 해당하는 일기 전체 조회 api를 구현했습니다.
날짜를 반환하는 format을 위해 util을 구현했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 구현화면
<img width="1470" alt="스크린샷 2024-07-19 오후 3 11 43" src="https://github.com/user-attachments/assets/0bf80dd6-9539-431a-906e-6a45876e074b">
