### PR TITLE
[feat] 일기 상세 조회 api 구현 #23

### DIFF
--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/controller/EmotionDiaryController.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/controller/EmotionDiaryController.java
@@ -1,6 +1,7 @@
 package com.zen.ZenServer.api.emotionDiary.controller;
 
 import com.zen.ZenServer.api.emotionDiary.dto.request.EmotionDiaryPostRequest;
+import com.zen.ZenServer.api.emotionDiary.dto.response.EmotionDiaryDetailGetResponse;
 import com.zen.ZenServer.api.emotionDiary.dto.response.EmotionDiaryListGetResponse;
 import com.zen.ZenServer.api.emotionDiary.service.EmotionDiaryService;
 import com.zen.ZenServer.global.client.gpt.GptService;
@@ -9,6 +10,7 @@ import com.zen.ZenServer.global.response.enums.SuccessCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,14 +29,23 @@ public class EmotionDiaryController {
     @PostMapping("/emotion-diary")
     public ApiResponseDto postEmotionDiary(@RequestBody EmotionDiaryPostRequest request) {
 
-        String gptAnswer = gptService.getAnswer(request);
+        String gptSummary = gptService.getSummary(request);
+        String gptAnswer = gptService.getAnswer(gptSummary,request);
 
-        emotionDiaryService.postEmotionDiary(userId,request,gptAnswer);
+        emotionDiaryService.postEmotionDiary(userId,request,gptSummary,gptAnswer);
         return ApiResponseDto.success(SuccessCode.EMOTIONDIARY_POST_SUCCESS);
     }
 
     @GetMapping("/diary-list")
     public ApiResponseDto<List<EmotionDiaryListGetResponse>> getDiaryList() {
         return ApiResponseDto.success(SuccessCode.EMOTIONDIARY_LIST_GET_SUCCESS,emotionDiaryService.getEmotionDiaryList(userId));
+    }
+
+    @GetMapping("/emotion-diary/{emotionDiaryId}")
+    public ApiResponseDto<EmotionDiaryDetailGetResponse> getEmotionDiaryList(
+            @PathVariable Long emotionDiaryId
+    ) {
+        return ApiResponseDto.success(SuccessCode.EMOTIONDIARY_DETAIL_GET_SUCCESS,
+                emotionDiaryService.getEmotionDiaryDetail(emotionDiaryId));
     }
 }

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/domain/EmotionDiary.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/domain/EmotionDiary.java
@@ -26,7 +26,11 @@ public class EmotionDiary extends BaseTimeEntity {
 
     private String inputText;
 
+    private String gptSummary;
+
     private String gptAnswer;
 
     private String userCharacter;
+
+    private String emotionState;
 }

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/domain/EmotionState.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/domain/EmotionState.java
@@ -1,0 +1,14 @@
+package com.zen.ZenServer.api.emotionDiary.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EmotionState {
+    SAD("SAD"),
+    SOSO("SOSO"),
+    ANGRY("ANGRY"),
+    HAPPY("HAPPY");
+    private final String emotion;
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/dto/response/EmotionDiaryDetailGetResponse.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/dto/response/EmotionDiaryDetailGetResponse.java
@@ -1,0 +1,12 @@
+package com.zen.ZenServer.api.emotionDiary.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record EmotionDiaryDetailGetResponse (
+        String when,	//날짜
+        String emotion,	//감정
+        String	summary,	//사용자가 입력한 내용 요약
+        String	solution	//gpt가 제공한 답변
+){
+}

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/repository/EmotionDiaryRepository.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/emotionDiary/repository/EmotionDiaryRepository.java
@@ -1,9 +1,17 @@
 package com.zen.ZenServer.api.emotionDiary.repository;
 
 import com.zen.ZenServer.api.emotionDiary.domain.EmotionDiary;
+import com.zen.ZenServer.api.user.domain.User;
+import com.zen.ZenServer.global.exception.CustomException;
+import com.zen.ZenServer.global.response.enums.ErrorCode;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmotionDiaryRepository extends JpaRepository<EmotionDiary, Long> {
     List<EmotionDiary> findByUserId(Long userId);
+
+    default EmotionDiary findByIdOrThrow(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.EMOTIONDIARY_NOT_FOUND));
+    }
 }

--- a/ZenServer/src/main/java/com/zen/ZenServer/api/user/repository/UserRepository.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/api/user/repository/UserRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String username);
 
-    default User findByIdByOrThrow(Long id) {
+    default User findByIdOrThrow(Long id) {
         return findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/ErrorCode.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "해당 유저는 존재하지 않습니다."),
     BASE_HEART_NOT_FOUND(40402, HttpStatus.NOT_FOUND, "base 심박이 존재하지 않습니다."),
     NOT_FOUND_GAME_RESULT(40403, HttpStatus.NOT_FOUND, "게임 결과가 존재하지 않습니다." ),
+    EMOTIONDIARY_NOT_FOUND(40003, HttpStatus.NOT_FOUND,"id에 해당하는 감정일기가 존재하지 않습니다."),
 
     // 405 Method Not Allowed Error
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),

--- a/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/SuccessCode.java
+++ b/ZenServer/src/main/java/com/zen/ZenServer/global/response/enums/SuccessCode.java
@@ -18,7 +18,8 @@ public enum SuccessCode {
     TETRIS_GET_RESULT_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 조회 성공"),
     TETRIS_GET_RESULT_LIST_SUCCESS(200, HttpStatus.OK, "테트리스 게임 결과 리스트 조회 성공"),
     EMOTIONDIARY_POST_SUCCESS(200,HttpStatus.OK,"사용자 답변 저장 성공"),
-    EMOTIONDIARY_LIST_GET_SUCCESS(200,HttpStatus.OK,"유저에 해당하는 일기 전체 조회 성공");
+    EMOTIONDIARY_LIST_GET_SUCCESS(200,HttpStatus.OK,"유저에 해당하는 일기 전체 조회 성공"),
+    EMOTIONDIARY_DETAIL_GET_SUCCESS(200, HttpStatus.OK,"일기 상세 조회 성공");
 
     private final int code;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #23 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- gpt 답변 로직을 추가했습니다.
    - 기존 gptAnswer를 gptSummary로 변경하였습니다.
    - gptAnswer 메소드를 통해 캐릭터별로 프롬프팅을 진행하였습니다.
    <img width="372" alt="스크린샷 2024-07-19 오후 6 20 48" src="https://github.com/user-attachments/assets/cfa8a7a0-b73f-4ef1-885d-1b0b2e34cd18">

    
- 일기 상세 조회 api를 구현했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 구현화면
<!-- postman 스크린샷 혹은 구현된 화면을 첨부해주세요 -->
<img width="1470" alt="스크린샷 2024-07-19 오후 5 20 05" src="https://github.com/user-attachments/assets/dfe340eb-2726-4b62-ade1-fb6d214979d1">
